### PR TITLE
add gitignore to ignore build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+topleft.exe
+topright.exe

--- a/topnotify.cs
+++ b/topnotify.cs
@@ -3,6 +3,7 @@ using System.Windows.Forms;
 using System.Runtime.InteropServices;
 using System.Drawing;
 using System.Threading;
+using System.Threading.Tasks;
 
 public class Program {
 
@@ -32,74 +33,88 @@ public class Program {
     public static int Cooldown; // Since The Teams Notification Stutters, Add A Cooldown To Dismiss
 
     public static void Main(string[] args) {
+        NotifyIcon notifyIcon = new NotifyIcon();
+        notifyIcon.Icon = SystemIcons.Application;
+        notifyIcon.Visible = true;
 
-        while (true) {
+        // Create the context menu for the taskbar icon
+        ContextMenu contextMenu = new ContextMenu();
+        MenuItem exitMenuItem = new MenuItem("Exit");
+        exitMenuItem.Click += new EventHandler(ExitMenuItem_Click);
+        contextMenu.MenuItems.Add(exitMenuItem);
+        notifyIcon.ContextMenu = contextMenu;
 
-            //MS Teams Notifications
-            try{
-                var teamsHwnd = FindWindow("Chrome_WidgetWin_1", "Microsoft Teams Notification");
-                var chromeHwnd = FindWindowEx(teamsHwnd, IntPtr.Zero, "Chrome_RenderWidgetHostHWND", "Chrome Legacy Window"); // I Think MS Is Using Chrome Webview For Notifications
+        // Run the main logic in another task to avoid blocking the main one with the while loop.
+        Task.Run(() => {
+            while (true) {
 
-                //If A Notification Is Showing Up
-                if (chromeHwnd != IntPtr.Zero){
-                    Cooldown = 0;
+                //MS Teams Notifications
+                try{
+                    var teamsHwnd = FindWindow("Chrome_WidgetWin_1", "Microsoft Teams Notification");
+                    var chromeHwnd = FindWindowEx(teamsHwnd, IntPtr.Zero, "Chrome_RenderWidgetHostHWND", "Chrome Legacy Window"); // I Think MS Is Using Chrome Webview For Notifications
 
-                    if (System.AppDomain.CurrentDomain.FriendlyName == "topleft.exe"){
-                        //Sets to top left
-                        SetWindowPos(teamsHwnd, 0, 15, 15, 100, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
-                    }
-                    else if (System.AppDomain.CurrentDomain.FriendlyName == "topright.exe"){
-                        //Sets to top right
-                        
-                        
-                        //Get the current position of the notification window
-                        Rectangle NotifyRect = new Rectangle();
-                        GetWindowRect(teamsHwnd, ref NotifyRect);
-                        
-                        NotifyRect.Width = NotifyRect.Width - NotifyRect.X;
-                        NotifyRect.Height = NotifyRect.Height - NotifyRect.Y;
-
-                        SetWindowPos(teamsHwnd, 0, Screen.PrimaryScreen.Bounds.Width - NotifyRect.Width - 15, 15, 100, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
-                    }
-                }
-                else {
-                    if (Cooldown >= 30){
-                        SetWindowPos(teamsHwnd, 0, 0, -9999, -9999, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW); // Move To Off Screen
+                    //If A Notification Is Showing Up
+                    if (chromeHwnd != IntPtr.Zero){
                         Cooldown = 0;
+
+                        if (System.AppDomain.CurrentDomain.FriendlyName == "topleft.exe"){
+                            //Sets to top left
+                            SetWindowPos(teamsHwnd, 0, 15, 15, 100, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
+                        }
+                        else if (System.AppDomain.CurrentDomain.FriendlyName == "topright.exe"){
+                            //Sets to top right
+
+                            //Get the current position of the notification window
+                            Rectangle NotifyRect = new Rectangle();
+                            GetWindowRect(teamsHwnd, ref NotifyRect);
+
+                            NotifyRect.Width = NotifyRect.Width - NotifyRect.X;
+                            NotifyRect.Height = NotifyRect.Height - NotifyRect.Y;
+
+                            SetWindowPos(teamsHwnd, 0, Screen.PrimaryScreen.Bounds.Width - NotifyRect.Width - 15, 15, 100, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
+                        }
                     }
-                    Cooldown += 1; // Don't Dismiss Until 30 Frames After Signal, Prevents Stutters
+                    else {
+                        if (Cooldown >= 30){
+                            SetWindowPos(teamsHwnd, 0, 0, -9999, -9999, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW); // Move To Off Screen
+                            Cooldown = 0;
+                        }
+                        Cooldown += 1; // Don't Dismiss Until 30 Frames After Signal, Prevents Stutters
+                    }
                 }
+                catch{
+                    //User Doesn't Have Teams
+                }
+
+                //Windows System Notifications
+                var hwnd = FindWindow("Windows.UI.Core.CoreWindow", "New notification");
+                if (System.AppDomain.CurrentDomain.FriendlyName == "topleft.exe"){
+                    //Sets to top left (easy peasy)
+                    //50PX Y offset to make the spacing even
+                    SetWindowPos(hwnd, 0, 0, -50, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
+                }
+                else if (System.AppDomain.CurrentDomain.FriendlyName == "topright.exe"){
+                    //Sets to top right (not as easy)
+
+                    //Get the current position of the notification window
+                    Rectangle NotifyRect = new Rectangle();
+                    GetWindowRect(hwnd, ref NotifyRect);
+
+                    NotifyRect.Width = NotifyRect.Width - NotifyRect.X;
+                                NotifyRect.Height = NotifyRect.Height - NotifyRect.Y;
+
+                    //50PX Y offset to make the spacing even
+                    SetWindowPos(hwnd, 0, Screen.PrimaryScreen.Bounds.Width - NotifyRect.Width, -50, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
+                }
+
+                Thread.Sleep(10);
             }
-            catch{
-                //User Doesn't Have Teams
-            }
+        });
 
-            //Windows System Notifications
-            var hwnd = FindWindow("Windows.UI.Core.CoreWindow", "New notification");
-            if (System.AppDomain.CurrentDomain.FriendlyName == "topleft.exe"){
-                //Sets to top left (easy peasy)
-                //50PX Y offset to make the spacing even
-                SetWindowPos(hwnd, 0, 0, -50, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
-            }
-            else if (System.AppDomain.CurrentDomain.FriendlyName == "topright.exe"){
-                //Sets to top right (not as easy)
+        Application.Run();
+    }
 
-                //Get the current position of the notification window
-                Rectangle NotifyRect = new Rectangle();
-                GetWindowRect(hwnd, ref NotifyRect);
-                
-                NotifyRect.Width = NotifyRect.Width - NotifyRect.X;
-			    NotifyRect.Height = NotifyRect.Height - NotifyRect.Y;
-
-                //50PX Y offset to make the spacing even
-                SetWindowPos(hwnd, 0, Screen.PrimaryScreen.Bounds.Width - NotifyRect.Width, -50, 0, 0, SWP_NOSIZE | SWP_NOZORDER | SWP_SHOWWINDOW);
-            }
-
-            Thread.Sleep(10);
-        }
-
-        
-        Console.ReadLine();
-
+    private static void ExitMenuItem_Click(object sender, EventArgs e) {
+        Application.Exit();
     }
 }


### PR DESCRIPTION
When you run the app, the only way to close it is to force it through the task manager. This PR adds an icon to the taskbar, which serves to show the user that the app is indeed running and offers a way to close it.