### PR TITLE
Add github action to build and release automatically

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,34 @@
+name: Build and Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Build executables
+        run: ${{ github.workspace }}/build.cmd
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: notifications-at-top
+          path: |
+            ${{ github.workspace }}/topleft.exe
+            ${{ github.workspace }}/topright.exe
+
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            topleft.exe
+            topright.exe


### PR DESCRIPTION
This PR adds an action that runs automatically on every new GitHub release, building the binaries and attaching them to the release and build artifacts. You can check the result here: https://github.com/GabrielDuarteM/notifications-at-top/releases/tag/v1.2.4 and also the build result here: https://github.com/GabrielDuarteM/notifications-at-top/actions/runs/4521771126